### PR TITLE
perf: reusable, internal buffer in sender/receiver

### DIFF
--- a/benches/crypto.rs
+++ b/benches/crypto.rs
@@ -17,7 +17,10 @@ fn create_random_payload(size: usize) -> Vec<u8> {
     unencrypted_payload
 }
 fn create_random_encrypted_payload(size: usize, sender: &mut Sender) -> Vec<u8> {
-    sender.encrypt(&create_random_payload(size), SKIP).unwrap()
+    sender
+        .encrypt(&create_random_payload(size), SKIP)
+        .unwrap()
+        .into()
 }
 
 struct CryptoBenches {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -20,13 +20,11 @@ fn encrypt_decrypt_1000_frames(participant_id: u64, skipped_payload: usize) {
         let mut media_frame = vec![0u8; 64];
         thread_rng().fill(media_frame.as_mut_slice());
 
-        let mut encrypted_frame = sender
+        let encrypted_frame = sender
             .encrypt(media_frame.as_slice(), skipped_payload)
             .unwrap();
 
-        let decrypted_frame = receiver
-            .decrypt(encrypted_frame.as_mut_slice(), skipped_payload)
-            .unwrap();
+        let decrypted_frame = receiver.decrypt(encrypted_frame, skipped_payload).unwrap();
 
         assert_eq!(media_frame, decrypted_frame);
     });


### PR DESCRIPTION
This yielded a performance improvement of around 10-15% on my local machine.

BREAKING CHANGE: decrypt requires receiver to be mutable. Also the user is now responsible of copying data on subsequential encrypt/decrypt calls. E.g.
        let frame = sender
            .encrypt(&data, 0)?;
        let frame2 = sender
            .encrypt(&data2, 0)?;
could be replaced with
        let frame = sender
            .encrypt(&data, 0)?
            .to_vec();
        let frame2 = sender
            .encrypt(&data2, 0)?;