### PR TITLE
test: use correct updated test vectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,6 @@ jobs:
         with:
           command: test
 
-      - name: verify test vectors
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib --features verify-test-vectors
-
       - name: clippy
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ test_vectors = { version = "0.1.0", path = "utils/test_vectors" }
 [features]
 default = []
 wasm-bindgen = ["ring/wasm32_c"]
-verify-test-vectors = []
 
 [[bench]]
 name = "bench_main"

--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -168,7 +168,6 @@ mod test {
                 .unwrap();
         }
 
-        #[cfg(feature = "verify-test-vectors")]
         mod test_vectors {
             use test_vectors::get_test_vector;
 

--- a/src/header/basic_header.rs
+++ b/src/header/basic_header.rs
@@ -107,7 +107,6 @@ impl Deserialization for BasicHeader {
 }
 
 #[cfg(test)]
-#[cfg(not(feature = "verify-test-vectors"))]
 mod test {
     use crate::{
         header::{BasicHeader, Deserialization, FrameCount, HeaderFields, Serialization},

--- a/src/header/extended_header.rs
+++ b/src/header/extended_header.rs
@@ -121,7 +121,6 @@ impl Deserialization for ExtendedHeader {
 }
 
 #[cfg(test)]
-#[cfg(not(feature = "verify-test-vectors"))]
 mod test {
     use crate::{
         header::{Deserialization, ExtendedHeader, FrameCount, HeaderFields, Serialization},

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -211,18 +211,12 @@ impl From<&Header> for Vec<u8> {
     }
 }
 
-// TODO remove the verify-test-vectors feature as soon the test vectors are fixed in the draft
-// Due to a spec change the lenghth offset changed (0 now means lenght of 1)
-#[cfg(not(feature = "verify-test-vectors"))]
 const LEN_OFFSET: u8 = 1;
-#[cfg(feature = "verify-test-vectors")]
-const LEN_OFFSET: u8 = 0;
 #[cfg(test)]
 mod test {
 
     use super::{frame_count::FrameCount, keyid::KeyId, Header};
     use crate::header::{Deserialization, HeaderFields};
-    #[cfg(feature = "verify-test-vectors")]
     use crate::util::test::assert_bytes_eq;
 
     use pretty_assertions::assert_eq;
@@ -258,7 +252,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "verify-test-vectors")]
     fn serialize_test_vectors() {
         test_vectors::get_test_vector(crate::CipherSuiteVariant::AesGcm128Sha256 as u8)
             .encryptions
@@ -273,7 +266,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "verify-test-vectors")]
     fn deserialize_test_vectors() {
         test_vectors::get_test_vector(crate::CipherSuiteVariant::AesGcm256Sha512 as u8)
             .encryptions

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -115,7 +115,6 @@ impl Sender {
 }
 
 #[cfg(test)]
-#[cfg(not(feature = "verify-test-vectors"))]
 mod test_on_wire_format {
     use super::*;
     use crate::receiver::Receiver;

--- a/utils/test_vectors/src/test-vectors.json
+++ b/utils/test_vectors/src/test-vectors.json
@@ -9,51 +9,51 @@
       {
         "kid": 7,
         "ctr": 0,
-        "header": "1700",
+        "header": "0700",
         "nonce": "42d662fbad5cd81eb3aad79a",
-        "ciphertext": "1700c5095af9dbbbed6a952de114ea7b42768509f1ffc9749abb1e95bf4514d8d82a0eef4b5ecac16fa193977fa1aa1c9fa5c7e73093ab2a43"
+        "ciphertext": "0700c5095af9dbbbed6a952de114ea7b42768509f1ffc9749abb1e95bf4514d8d82a0eef4b5ecac16fa193977fa1aa1c9fa5c7e730b934669c"
       },
       {
         "kid": 7,
         "ctr": 1,
-        "header": "1701",
+        "header": "0701",
         "nonce": "42d662fbad5cd81eb3aad79b",
-        "ciphertext": "1701559e262525382885c6c93be8f61a9064db2dd1e1e96ab1dbd829ca4af4f45f2b97a4889217a3f8a2159fb8201b7d71db01702bd4bab5c7"
+        "ciphertext": "0701559e262525382885c6c93be8f61a9064db2dd1e1e96ab1dbd829ca4af4f45f2b97a4889217a3f8a2159fb8201b7d71db01702b9caf8df6"
       },
       {
         "kid": 7,
         "ctr": 2,
-        "header": "1702",
+        "header": "0702",
         "nonce": "42d662fbad5cd81eb3aad798",
-        "ciphertext": "17020a8f21e052eaa09e50da0a909d156cc55b9ef2f2abbcca765f7af3cfb1af234e3eac1dbc376631c83cf1ff1f8ab339dbc41044cc930d87"
+        "ciphertext": "07020a8f21e052eaa09e50da0a909d156cc55b9ef2f2abbcca765f7af3cfb1af234e3eac1dbc376631c83cf1ff1f8ab339dbc41044742c668d"
       },
       {
         "kid": 15,
         "ctr": 170,
-        "header": "190faa",
+        "header": "080faa",
         "nonce": "42d662fbad5cd81eb3aad730",
-        "ciphertext": "190faa9c65aa5b167873f25827f17bc34879a4aaa6b38dd9584472e1849d5da51555f288d08f03166a5f26af01794006255c88b58986246287c9"
+        "ciphertext": "080faa9c65aa5b167873f25827f17bc34879a4aaa6b38dd9584472e1849d5da51555f288d08f03166a5f26af01794006255c88b589861e2f8e3e"
       },
       {
         "kid": 511,
         "ctr": 170,
-        "header": "1a01ffaa",
+        "header": "0901ffaa",
         "nonce": "42d662fbad5cd81eb3aad730",
-        "ciphertext": "1a01ffaa9c65aa5b167873f25827f17bc34879a4aaa6b38dd9584472e1849d5da51555f288d08f03166a5f26af01794006255c88b589863003872e"
+        "ciphertext": "0901ffaa9c65aa5b167873f25827f17bc34879a4aaa6b38dd9584472e1849d5da51555f288d08f03166a5f26af01794006255c88b58986ca1ead10"
       },
       {
         "kid": 511,
         "ctr": 43690,
-        "header": "2a01ffaaaa",
+        "header": "1901ffaaaa",
         "nonce": "42d662fbad5cd81eb3aa7d30",
-        "ciphertext": "2a01ffaaaa990cbeb4ae2e3a76be8bb954b62591e791d0fa53c0553bc1d1e021d270b1a10688cd89195203b01978925373b04f9c08c3a4e5fb0173ef"
+        "ciphertext": "1901ffaaaa990cbeb4ae2e3a76be8bb954b62591e791d0fa53c0553bc1d1e021d270b1a10688cd89195203b01978925373b04f9c08c3a4e563e2f6b9"
       },
       {
         "kid": 72057594037927935,
         "ctr": 72057594037927935,
-        "header": "7fffffffffffffffffffffffffffff",
+        "header": "6effffffffffffffffffffffffffff",
         "nonce": "42d662fbada327e14c552865",
-        "ciphertext": "7fffffffffffffffffffffffffffff412c43c8077c286f7df3dd9988d1bd033f1067493e09421e5bfc363e50a3c803b4da9239514cb924dbcb5f33e33112083e99103ef272e8"
+        "ciphertext": "6effffffffffffffffffffffffffff412c43c8077c286f7df3dd9988d1bd033f1067493e09421e5bfc363e50a3c803b4da9239514cb924dbcb5f33e33112083e99108de2ecd6"
       }
     ]
   },
@@ -67,51 +67,51 @@
       {
         "kid": 7,
         "ctr": 0,
-        "header": "1700",
+        "header": "0700",
         "nonce": "77fbf5f1d82c73f6d2b353c9",
-        "ciphertext": "17009d89e5753e06edf3025f1ccd70b095ebaf10c250e11da740f50f57b6ce860d7321dfa49688a2cd6c6d9a71ae9d5c14ad0978efe0216ae5f6788ffe"
+        "ciphertext": "07009d89e5753e06edf3025f1ccd70b095ebaf10c250e11da740f50f57b6ce860d7321dfa49688a2cd6c6d9a71ae9d5c14ad0978efdd719a7f18c48f07"
       },
       {
         "kid": 7,
         "ctr": 1,
-        "header": "1701",
+        "header": "0701",
         "nonce": "77fbf5f1d82c73f6d2b353c8",
-        "ciphertext": "1701becd2e9d10e3eed586491b3e0ecedba89407ae2151787c5117b55707d6b8a0754f4dc937e30ebdf7cafbd3769d6585d7991b1aa6f36e418fdec6fa"
+        "ciphertext": "0701becd2e9d10e3eed586491b3e0ecedba89407ae2151787c5117b55707d6b8a0754f4dc937e30ebdf7cafbd3769d6585d7991b1a6bd31e8bddb1adec"
       },
       {
         "kid": 7,
         "ctr": 2,
-        "header": "1702",
+        "header": "0702",
         "nonce": "77fbf5f1d82c73f6d2b353cb",
-        "ciphertext": "170298508be6b16d034f15b504ced45a86d1bb43ed7cd3a62bf25557d1b082b04e8e6ba6fe76160835dd8953e1be9640c988627ea4f1bb846e87523f8b"
+        "ciphertext": "070298508be6b16d034f15b504ced45a86d1bb43ed7cd3a62bf25557d1b082b04e8e6ba6fe76160835dd8953e1be9640c988627ea447127ae4c103eabd"
       },
       {
         "kid": 15,
         "ctr": 170,
-        "header": "190faa",
+        "header": "080faa",
         "nonce": "77fbf5f1d82c73f6d2b35363",
-        "ciphertext": "190faae7eec4b0556ddfb8068998351cd670ce95f0ce9cd4c6dca2eeee73fb14d20a0d0fd487337ed43fa7f98dad0995b8b870325aa349ac0590c2745d5d"
+        "ciphertext": "080faae7eec4b0556ddfb8068998351cd670ce95f0ce9cd4c6dca2eeee73fb14d20a0d0fd487337ed43fa7f98dad0995b8b870325aa35a105af9b1004b22"
       },
       {
         "kid": 511,
         "ctr": 170,
-        "header": "1a01ffaa",
+        "header": "0901ffaa",
         "nonce": "77fbf5f1d82c73f6d2b35363",
-        "ciphertext": "1a01ffaae7eec4b0556ddfb8068998351cd670ce95f0ce9cd4c6dca2eeee73fb14d20a0d0fd487337ed43fa7f98dad0995b8b870325aa31d576e8a34093320"
+        "ciphertext": "0901ffaae7eec4b0556ddfb8068998351cd670ce95f0ce9cd4c6dca2eeee73fb14d20a0d0fd487337ed43fa7f98dad0995b8b870325aa3437cce05a6e67ee8"
       },
       {
         "kid": 511,
         "ctr": 43690,
-        "header": "2a01ffaaaa",
+        "header": "1901ffaaaa",
         "nonce": "77fbf5f1d82c73f6d2b3f963",
-        "ciphertext": "2a01ffaaaa8c1789aa0abcd6abc27006aae4df5cba4ba07f8113080e9726baacd16c18539974a6204a36b9dc3dcd36ed9ab48e590d95d4ad1b05f8375508c55d"
+        "ciphertext": "1901ffaaaa8c1789aa0abcd6abc27006aae4df5cba4ba07f8113080e9726baacd16c18539974a6204a36b9dc3dcd36ed9ab48e590d95d4adfb4290f4cb1ba184"
       },
       {
         "kid": 72057594037927935,
         "ctr": 72057594037927935,
-        "header": "7fffffffffffffffffffffffffffff",
+        "header": "6effffffffffffffffffffffffffff",
         "nonce": "77fbf5f1d8d38c092d4cac36",
-        "ciphertext": "7fffffffffffffffffffffffffffffa9bc6c7edde0fdfd13255a5b145c5ce84db8f8960858eb998b8ea8f3e770160150813c5806441b64251bdd2be9e8cec1386b6f5e73eaa6c19e6555"
+        "ciphertext": "6effffffffffffffffffffffffffffa9bc6c7edde0fdfd13255a5b145c5ce84db8f8960858eb998b8ea8f3e770160150813c5806441b64251bdd2be9e8cec1386b6f8e3b1982bcd16c84"
       }
     ]
   },
@@ -125,51 +125,51 @@
       {
         "kid": 7,
         "ctr": 0,
-        "header": "1700",
+        "header": "0700",
         "nonce": "a80478b3f6fba19983d540d5",
-        "ciphertext": "17000e426255e47ed70dd7d15d69d759bf459032ca15f5e8b2a91e7d348aa7c186d403f620801c495b1717a35097411aa97cbb140671eb3b49ac3775926db74d57b91e8e6c"
+        "ciphertext": "07000e426255e47ed70dd7d15d69d759bf459032ca15f5e8b2a91e7d348aa7c186d403f620801c495b1717a35097411aa97cbb1406afd9f4e5215b46e4a39dc40c27fd6bc7"
       },
       {
         "kid": 7,
         "ctr": 1,
-        "header": "1701",
+        "header": "0701",
         "nonce": "a80478b3f6fba19983d540d4",
-        "ciphertext": "170103bbafa34ada8a6b9f2066bc34a1959d87384c9f4b1ce34fed58e938bde143393910b1aeb55b48d91d5b0db3ea67e3d0e02b843afd41630c940b1948e72dd45396a43a"
+        "ciphertext": "070103bbafa34ada8a6b9f2066bc34a1959d87384c9f4b1ce34fed58e938bde143393910b1aeb55b48d91d5b0db3ea67e3d0e02b84e4cf8ecf81f8386f86cda48fcd754191"
       },
       {
         "kid": 7,
         "ctr": 2,
-        "header": "1702",
+        "header": "0702",
         "nonce": "a80478b3f6fba19983d540d7",
-        "ciphertext": "170258d58adebd8bf6f3cc0c1fcacf34ba4d7a763b2683fe302a57f1be7f2a274bf81b2236995fec1203cadb146cd402e1c52d5e6a10989dfe0f4116da1ee4c2fad0d21f8f"
+        "ciphertext": "070258d58adebd8bf6f3cc0c1fcacf34ba4d7a763b2683fe302a57f1be7f2a274bf81b2236995fec1203cadb146cd402e1c52d5e6aceaa5252822d25acd0ce4ba14e31fa24"
       },
       {
         "kid": 15,
         "ctr": 170,
-        "header": "190faa",
+        "header": "080faa",
         "nonce": "a80478b3f6fba19983d5407f",
-        "ciphertext": "190faad0b1743bf5248f90869c9456366d55724d16bbe08060875815565e90b114f9ccbdba192422b33848a1ae1e3bd266a001b2f5bb727112772e0072ea8679ca1850cf11d8"
+        "ciphertext": "080faad0b1743bf5248f90869c9456366d55724d16bbe08060875815565e90b114f9ccbdba192422b33848a1ae1e3bd266a001b2f5bb64c0f1216bba82ab24b1ebd677c2ca29"
       },
       {
         "kid": 511,
         "ctr": 170,
-        "header": "1a01ffaa",
+        "header": "0901ffaa",
         "nonce": "a80478b3f6fba19983d5407f",
-        "ciphertext": "1a01ffaad0b1743bf5248f90869c9456366d55724d16bbe08060875815565e90b114f9ccbdba192422b33848a1ae1e3bd266a001b2f5bbc9c63bd3973c19bd57127f565380ed4a"
+        "ciphertext": "0901ffaad0b1743bf5248f90869c9456366d55724d16bbe08060875815565e90b114f9ccbdba192422b33848a1ae1e3bd266a001b2f5bb8c718170432b6f922c1f0fb307514a0e"
       },
       {
         "kid": 511,
         "ctr": 43690,
-        "header": "2a01ffaaaa",
+        "header": "1901ffaaaa",
         "nonce": "a80478b3f6fba19983d5ea7f",
-        "ciphertext": "2a01ffaaaa9de65e21e4f1ca2247b87943c03c5cb7b182090e93d508dcfb76e08174c6397356e682d2eaddabc0b3c1018d2c13c3570f61c1beaab805f27b565e1329a823a7a649b6"
+        "ciphertext": "1901ffaaaa9de65e21e4f1ca2247b87943c03c5cb7b182090e93d508dcfb76e08174c6397356e682d2eaddabc0b3c1018d2c13c3570f61c185789dff3cb4469cf471ca71ceb025a5"
       },
       {
         "kid": 72057594037927935,
         "ctr": 72057594037927935,
-        "header": "7fffffffffffffffffffffffffffff",
+        "header": "6effffffffffffffffffffffffffff",
         "nonce": "a80478b3f6045e667c2abf2a",
-        "ciphertext": "7fffffffffffffffffffffffffffff09981bdcdad80e380b6f74cf6afdbce946839bedadd57578bfcd809dbcea535546cc24660613d2761adea852155785011e633534f4ecc3b8257c8d34321c27854a1422"
+        "ciphertext": "6effffffffffffffffffffffffffff09981bdcdad80e380b6f74cf6afdbce946839bedadd57578bfcd809dbcea535546cc24660613d2761adea852155785011e633522450f95fd9f8ccc96fa3de9a247cfd3"
       }
     ]
   },
@@ -183,51 +183,51 @@
       {
         "kid": 7,
         "ctr": 0,
-        "header": "1700",
+        "header": "0700",
         "nonce": "31ed26f90a072e6aee646298",
-        "ciphertext": "1700f3e297c1e95207710bd31ccc4ba396fbef7b257440bde638ff0f3c8911540136df61b26220249d6c432c245ae8d55ef45bfccf32530a15aeaaf313a03838e51bd45652"
+        "ciphertext": "0700f3e297c1e95207710bd31ccc4ba396fbef7b257440bde638ff0f3c8911540136df61b26220249d6c432c245ae8d55ef45bfccf3afe18dd36d64d8e341653e1a0f10be2"
       },
       {
         "kid": 7,
         "ctr": 1,
-        "header": "1701",
+        "header": "0701",
         "nonce": "31ed26f90a072e6aee646299",
-        "ciphertext": "170193268b0bf030071bff443bb6b4471bdfb1cc81bc9625f4697b0336ff4665d15f152f02169448d8a967fb06359a87d2145398de0ce3fbe257b0992a3da1537590459f3c"
+        "ciphertext": "070193268b0bf030071bff443bb6b4471bdfb1cc81bc9625f4697b0336ff4665d15f152f02169448d8a967fb06359a87d2145398de044ee92acfcc27b7a98f38712b60c28c"
       },
       {
         "kid": 7,
         "ctr": 2,
-        "header": "1702",
+        "header": "0702",
         "nonce": "31ed26f90a072e6aee64629a",
-        "ciphertext": "1702649691ba27c4c01a41280fba4657c03fa7fe21c8f5c862e9094227c3ca3ec0d9468b1a2cb060ff0978f25a24e6b106f5a6e1053c1b8f5fce794d88a0e4818c081e18ea"
+        "ciphertext": "0702649691ba27c4c01a41280fba4657c03fa7fe21c8f5c862e9094227c3ca3ec0d9468b1a2cb060ff0978f25a24e6b106f5a6e10534b69d975605f31534caea88b33b455a"
       },
       {
         "kid": 15,
         "ctr": 170,
-        "header": "190faa",
+        "header": "080faa",
         "nonce": "31ed26f90a072e6aee646232",
-        "ciphertext": "190faa2858c10b5ddd231c1f26819490521678603a050448d563c503b1fd890d02ead01d754f074ecb6f32da9b2f3859f380b4f47d4edd1e15f42f9a2d7ecfac99067e238321"
+        "ciphertext": "080faa2858c10b5ddd231c1f26819490521678603a050448d563c503b1fd890d02ead01d754f074ecb6f32da9b2f3859f380b4f47d4ed539d6103e61580a82c014b28eb48b4a"
       },
       {
         "kid": 511,
         "ctr": 170,
-        "header": "1a01ffaa",
+        "header": "0901ffaa",
         "nonce": "31ed26f90a072e6aee646232",
-        "ciphertext": "1a01ffaa2858c10b5ddd231c1f26819490521678603a050448d563c503b1fd890d02ead01d754f074ecb6f32da9b2f3859f380b4f47d4e3bf7040eb10ec25b8126b2ce7b1d9d31"
+        "ciphertext": "0901ffaa2858c10b5ddd231c1f26819490521678603a050448d563c503b1fd890d02ead01d754f074ecb6f32da9b2f3859f380b4f47d4e32c565b3b3fa20fc7ecff21a1cee3eec"
       },
       {
         "kid": 511,
         "ctr": 43690,
-        "header": "2a01ffaaaa",
+        "header": "1901ffaaaa",
         "nonce": "31ed26f90a072e6aee64c832",
-        "ciphertext": "2a01ffaaaad9bc6a258a07d210a814d545eca70321c0e87498ada6e5c708b7ead162ffcf4fbaba1eb82650590a87122b4d95fe36bd88b278812166d26e046ed0a530b7ee232ee0f2"
+        "ciphertext": "1901ffaaaad9bc6a258a07d210a814d545eca70321c0e87498ada6e5c708b7ead162ffcf4fbaba1eb82650590a87122b4d95fe36bd88b278994922fe5c09f14c728521333297f84f"
       },
       {
         "kid": 72057594037927935,
         "ctr": 72057594037927935,
-        "header": "7fffffffffffffffffffffffffffff",
+        "header": "6effffffffffffffffffffffffffff",
         "nonce": "31ed26f90af8d195119b9d67",
-        "ciphertext": "7fffffffffffffffffffffffffffffaf480d4779ce0c02b5137ee6a61e026c04ac999cb0c97319feceeb258d58df23bce14979e5c67a431777b34498062e72f939ca42ec84ffbc7b50eff923f515a2df760c"
+        "ciphertext": "6effffffffffffffffffffffffffffaf480d4779ce0c02b5137ee6a61e026c04ac999cb0c97319feceeb258d58df23bce14979e5c67a431777b34498062e72f939ca4acb471bad80259bb44f78a152487e67"
       }
     ]
   }


### PR DESCRIPTION
By adapting the generator script in the sframe-wg repo, we can regenerate the test vectors.
 With those we no longer need a feature flag to test against them